### PR TITLE
feat: use PyPI API to find pypi package download URL.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,7 @@ dependencies = [
  "futures",
  "log",
  "reqwest",
+ "serde",
  "sha2",
  "tokio",
 ]

--- a/abbs-update-checksum-core/Cargo.toml
+++ b/abbs-update-checksum-core/Cargo.toml
@@ -8,7 +8,8 @@ eyre = "0.6"
 abbs-meta-apml = { git = "https://github.com/AOSC-Dev/abbs-meta-rs", package = "abbs-meta-apml", rev = "4a592937b44e8bb93103edd34eff384169a3248a" }
 log = "0.4"
 sha2 = "0.10.8"
-reqwest = "0.12"
+reqwest = { version = "0.12", features = ["json"] }
 faster-hex = "0.10"
 tokio = { version = "1", features = ["macros"] }
 futures = "0.3"
+serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
PyPI automatically convert newly uploaded file name to lowercase, make API call necessary again. See also https://github.com/AOSC-Dev/acbs/pull/39/commits/8f84e88e6ce125e5982ffcd26b565fd545e45cb3